### PR TITLE
Optimize FileSelector.filter_files by avoiding repeated get_files calls

### DIFF
--- a/src/llm_context/file_selector.py
+++ b/src/llm_context/file_selector.py
@@ -120,7 +120,8 @@ class FileSelector:
         )
 
     def filter_files(self, files: list[str]) -> list[str]:
-        return [f for f in files if f in set(self.get_files())]
+        selected_files = set(self.get_files())
+        return [f for f in files if f in selected_files]
 
     def get_files(self) -> list[str]:
         files = list(set(self.traverse(self.root_path) + self.also_traverse(self.root_path)))

--- a/tests/test_include_filters.py
+++ b/tests/test_include_filters.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from llm_context.file_selector import FileSelector, IncludeFilter
 from llm_context.utils import PathConverter
@@ -350,6 +351,26 @@ class TestPathFormatNormalization(unittest.TestCase):
 
 class TestPerformanceAndRegression(unittest.TestCase):
     """Test performance characteristics and regression prevention"""
+
+    def test_filter_files_calls_get_files_once(self):
+        """filter_files should not repeatedly recompute get_files() results"""
+        selector = FileSelector.create(
+            Path("/tmp"),
+            ignore_pathspecs=[],
+            limit_to_pathspecs=["**/*"],
+            also_include_pathspecs=[],
+        )
+
+        with patch.object(
+            FileSelector,
+            "get_files",
+            autospec=True,
+            return_value=["/tmp/a.py", "/tmp/b.py"],
+        ) as mock_get_files:
+            filtered = selector.filter_files(["/tmp/a.py", "/tmp/c.py", "/tmp/b.py"])
+
+        self.assertEqual(filtered, ["/tmp/a.py", "/tmp/b.py"])
+        mock_get_files.assert_called_once_with(selector)
 
     def test_no_also_include_patterns_no_extra_traversal(self):
         """Test that empty also-include doesn't cause extra work"""


### PR DESCRIPTION
## What changed
- Updated `FileSelector.filter_files()` to build the selected-file set once per call instead of rebuilding it for every candidate file.
- Added a regression test (`test_filter_files_calls_get_files_once`) to guarantee `get_files()` is called exactly once and filtering behavior remains correct.

## Why
- `filter_files()` previously recomputed `set(self.get_files())` inside the list comprehension, which repeatedly reran an expensive filesystem traversal.
- This change keeps behavior identical while reducing unnecessary repeated work.

## Testing
- ✅ `source .venv/bin/activate && pytest -q`
